### PR TITLE
Configure Coveralls for coverage report

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
 python:
-  - "3.2"
   - "3.3"
   - "3.4"
+install:
+  - pip install coveralls
 script:
-  - python -m unittest discover
+  - coverage run --source=dgacollection -m unittest discover
+after_success:
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # DGA Collection
 
 [![Build Status](https://travis-ci.org/pchaigno/dga-collection.svg?branch=master)](https://travis-ci.org/pchaigno/dga-collection)
+[![Coverage Status](https://coveralls.io/repos/github/pchaigno/dga-collection/badge.svg?branch=master)](https://coveralls.io/github/pchaigno/dga-collection?branch=master)
 
 A collection of known [Domain Generation Algorithms](https://en.wikipedia.org/wiki/Domain_generation_algorithm):
 - [Torpig](https://seclab.cs.ucsb.edu/media/uploads/papers/torpig.pdf)


### PR DESCRIPTION
This pull request configures Coveralls with Travis CI to keep track of the evolutions of coverage percentage with new commits and pull requests.
